### PR TITLE
feat(api): POST /stations — dynamic station creation and upsert (#10)

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -59,6 +59,16 @@ const STATIONS = [
     djName: "DJ Alex",
     djBio: "An AI DJ powered by PlayGen. Curates OPM hits and talks between songs like a real radio host.",
   },
+  {
+    name: "Metro Manila Mix",
+    slug: "metro-manila-mix",
+    description: "Metro Manila's freshest mix — Taglish banter, OPM and international hits.",
+    stream: "",
+    metadata: "",
+    genre: "OPM",
+    djName: "Camille",
+    djBio: "Energetic Taglish DJ born and raised in QC. Loves OPM, EDSA stories, and good tapsilog.",
+  },
 ];
 
 async function main() {

--- a/apps/api/src/routes/stations.ts
+++ b/apps/api/src/routes/stations.ts
@@ -1,7 +1,88 @@
 import type { FastifyPluginAsync } from "fastify";
 import { prisma } from "../db/client.js";
 
+const WEBHOOK_SECRET = process.env.PLAYGEN_WEBHOOK_SECRET ?? "";
+
+function verifySecret(req: { headers: Record<string, string | string[] | undefined> }): boolean {
+  if (!WEBHOOK_SECRET) return true;
+  const header = req.headers["x-playgen-secret"];
+  const token = Array.isArray(header) ? header[0] : header;
+  return token === WEBHOOK_SECRET;
+}
+
+interface CreateStationBody {
+  slug: string;
+  name: string;
+  description?: string;
+  streamUrl?: string;
+  metadataUrl?: string;
+  genre?: string;
+  artworkUrl?: string;
+  isLive?: boolean;
+  dj?: {
+    name: string;
+    bio?: string;
+    avatarUrl?: string;
+  };
+}
+
 export const stationRoutes: FastifyPluginAsync = async (app) => {
+  // POST /stations — upsert by slug (requires X-PlayGen-Secret)
+  app.post<{ Body: CreateStationBody }>("/stations", async (request, reply) => {
+    if (!verifySecret(request)) {
+      return reply.status(401).send({ error: "Unauthorized" });
+    }
+    const { slug, name, description, streamUrl, metadataUrl, genre, artworkUrl, isLive, dj } =
+      request.body ?? {};
+
+    if (!slug || !name) {
+      return reply.status(400).send({ error: "slug and name are required" });
+    }
+
+    const existing = await prisma.station.findUnique({ where: { slug }, include: { dj: true } });
+
+    if (existing) {
+      // Upsert: update station fields; update or create DJ if provided
+      const updated = await prisma.station.update({
+        where: { slug },
+        data: {
+          name,
+          ...(description !== undefined && { description }),
+          ...(streamUrl !== undefined && { streamUrl }),
+          ...(metadataUrl !== undefined && { metadataUrl }),
+          ...(genre !== undefined && { genre }),
+          ...(artworkUrl !== undefined && { artworkUrl }),
+          ...(isLive !== undefined && { isLive }),
+          ...(dj && {
+            dj: existing.dj
+              ? { update: { data: { name: dj.name, bio: dj.bio ?? "", avatarUrl: dj.avatarUrl ?? null } } }
+              : { create: { name: dj.name, bio: dj.bio ?? "", avatarUrl: dj.avatarUrl ?? null } },
+          }),
+        },
+        include: { dj: true },
+      });
+      return reply.status(200).send(updated);
+    }
+
+    const created = await prisma.station.create({
+      data: {
+        slug,
+        name,
+        description: description ?? "",
+        streamUrl: streamUrl ?? "",
+        metadataUrl: metadataUrl ?? "",
+        genre: genre ?? "",
+        artworkUrl: artworkUrl ?? null,
+        isLive: isLive ?? false,
+        ...(dj && {
+          dj: { create: { name: dj.name, bio: dj.bio ?? "", avatarUrl: dj.avatarUrl ?? null } },
+        }),
+      },
+      include: { dj: true },
+    });
+    return reply.status(201).send(created);
+  });
+
   // GET /stations
   app.get("/stations", async (request, reply) => {
     const stations = await prisma.station.findMany({

--- a/apps/api/src/tests/routes/stations.test.ts
+++ b/apps/api/src/tests/routes/stations.test.ts
@@ -8,6 +8,8 @@ vi.mock("../../db/client.js", () => ({
     station: {
       findMany: vi.fn(),
       findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
     },
     song: {
       findMany: vi.fn(),
@@ -37,6 +39,98 @@ const MOCK_STATION = {
     avatarUrl: null,
   },
 };
+
+const NEW_STATION = {
+  id: "st-new",
+  name: "Metro Manila Mix",
+  slug: "metro-manila-mix",
+  description: "Metro Manila's Freshest Mix",
+  streamUrl: "https://cdn.example.com/metro/playlist.m3u8",
+  metadataUrl: null,
+  genre: "OPM",
+  artworkUrl: null,
+  isLive: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  dj: { id: "dj-new", stationId: "st-new", name: "Camille", bio: "Taglish DJ", avatarUrl: null },
+};
+
+describe("POST /stations", () => {
+  let app: Awaited<ReturnType<typeof buildApp>>;
+
+  beforeAll(async () => {
+    app = await buildApp();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it("creates a new station and returns 201", async () => {
+    vi.mocked(prisma.station.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.station.create).mockResolvedValue(NEW_STATION as any);
+
+    const res = await supertest(app.server)
+      .post("/stations")
+      .set("x-playgen-secret", "")
+      .send({
+        slug: "metro-manila-mix",
+        name: "Metro Manila Mix",
+        description: "Metro Manila's Freshest Mix",
+        genre: "OPM",
+        streamUrl: "https://cdn.example.com/metro/playlist.m3u8",
+        dj: { name: "Camille", bio: "Taglish DJ" },
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.slug).toBe("metro-manila-mix");
+    expect(res.body.dj.name).toBe("Camille");
+  });
+
+  it("upserts (200) when station slug already exists", async () => {
+    vi.mocked(prisma.station.findUnique).mockResolvedValue(NEW_STATION as any);
+    vi.mocked(prisma.station.update).mockResolvedValue({
+      ...NEW_STATION,
+      streamUrl: "https://cdn.example.com/metro/v2.m3u8",
+    } as any);
+
+    const res = await supertest(app.server)
+      .post("/stations")
+      .set("x-playgen-secret", "")
+      .send({
+        slug: "metro-manila-mix",
+        name: "Metro Manila Mix",
+        streamUrl: "https://cdn.example.com/metro/v2.m3u8",
+      });
+
+    expect(res.status).toBe(200);
+    expect(prisma.station.update).toHaveBeenCalledOnce();
+    expect(prisma.station.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when slug is missing", async () => {
+    const res = await supertest(app.server)
+      .post("/stations")
+      .set("x-playgen-secret", "")
+      .send({ name: "No Slug Station" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it("returns 400 when name is missing", async () => {
+    const res = await supertest(app.server)
+      .post("/stations")
+      .set("x-playgen-secret", "")
+      .send({ slug: "no-name" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+});
 
 describe("GET /stations", () => {
   let app: Awaited<ReturnType<typeof buildApp>>;


### PR DESCRIPTION
## Summary
- Adds `POST /stations` endpoint — creates or upserts a station by slug
- Auth via `X-PlayGen-Secret` header (same as existing webhook routes)
- Idempotent: slug already exists → 200 upsert; new slug → 201 create
- Adds Metro Manila Mix to `prisma/seed.ts` for fresh installs
- 4 new integration tests (create, upsert, missing slug, missing name)

## Why
Stations were only addable via `prisma db seed` which wipes all data first. PlayGen-generated stations (like Metro Manila Mix) had no way to appear on OwnRadio.net without a manual re-seed.

## Test plan
- [x] `npm test` — 17/17 tests pass
- [x] `npm run typecheck` — clean
- [ ] Verify `POST /stations` with `X-PlayGen-Secret` creates station visible in `GET /stations`
- [ ] Verify duplicate slug returns 200 (not 409/500)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)